### PR TITLE
Use the new dev subdomain for staging environment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/groovy
 
 @Library('github.com/bufferapp/k8s-jenkins-pipeline@master')
-def pipeline = new com.buffer.Pipeline3()
+def pipeline = new com.buffer.Pipeline4()
 
 pipeline.start('Jenkinsfile.json')

--- a/buffer-account/templates/deployment.yaml
+++ b/buffer-account/templates/deployment.yaml
@@ -8,7 +8,6 @@ metadata:
     track: {{ .Values.track }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     branch: {{ .Values.branchName }}
-  namespace: buffer
 spec:
   minReadySeconds: 10
   replicas: {{ .Values.replicaCount }}

--- a/buffer-account/templates/ingress.yaml
+++ b/buffer-account/templates/ingress.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
 spec:
   rules:
-    - host: "{{ .Values.branchSubdomain }}account.buffer.com"
+    - host: "{{ .Values.branchSubdomain }}account.dev.buffer.com"
       http:
         paths:
           - path: /

--- a/buffer-account/values.yaml
+++ b/buffer-account/values.yaml
@@ -21,7 +21,7 @@ ingress:
   hosts:
     - chart-example.local
   annotations:
-    # kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   tls:
     # Secrets must be manually created in the namespace.


### PR DESCRIPTION
### Purpose
Switch to using the new dev subdomain which needs to happen before the repo can be compatible with `kuberdash`'s CICD. 

### Notes
@stevenc81 since you did this for previous repos as well, was wondering if you could take a look at this and see if it looks ok? My hunch is that it should. I've switched it to Pipline4 since this repo is still using the us-east Jenkins CICD approach for now. 

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.account.dev.buffer.com :smile:_
